### PR TITLE
chore: remove the test timeout from the autotest

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Auto Test
 
 on:
@@ -12,7 +9,6 @@ permissions: {}
 jobs:
   auto-test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
     permissions:
       contents: read
 


### PR DESCRIPTION
# Summary

This fails some CI runs, when CI is being extra slow